### PR TITLE
Fix styles not loading properly in Safari

### DIFF
--- a/templates/public/countdown.html
+++ b/templates/public/countdown.html
@@ -16,7 +16,7 @@
 	<link rel="apple-touch-icon" sizes="114x114" href="/assets/public/img/apple-touch-icon-114x114.jpg">
 
 	<link rel="stylesheet" type="text/css" href="/assets/public/css/custom-animations.css" />
-	<link rel="stylesheet" type="text/css" href="/assets/public/css/style-blue-color.css" />
+	<link rel="stylesheet" type="text/css" href="/assets/public/css/min/style-blue-color.min.css" />
 
 	<!--[if lt IE 9]>
 		<script src="/assets/public/js/html5shiv.js"></script>


### PR DESCRIPTION
Loading the minified version of the CSS file fixes the problem in Safari. Possibly a line number limit in Safari since the style that is missing is at line number 5132. I've only heard of IE having line number limits though.

Fixes #44 