### PR TITLE
defer script execution until html is parsed

### DIFF
--- a/templates/public/index.html
+++ b/templates/public/index.html
@@ -2084,7 +2084,7 @@
 					<ul class="instagram-list">
 						<!-- InstaWidget -->
 						<a href="https://instawidget.net/v/tag/GopherCon" id="link-d041909748e13a0e9e07e94b550519a0e3255641606c578f54ce324ccf0269b0">#GopherCon</a>
-						<script src="https://instawidget.net/js/instawidget.js?u=d041909748e13a0e9e07e94b550519a0e3255641606c578f54ce324ccf0269b0&width=300px"></script>
+						<script defer src="https://instawidget.net/js/instawidget.js?u=d041909748e13a0e9e07e94b550519a0e3255641606c578f54ce324ccf0269b0&width=300px"></script>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
this should add a speed-up in page render time. The 'defer' attribute should be added to all of the instances of the instawidget script throughout the codebase. I only added it to the index.html template.